### PR TITLE
fix resources limit issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian
-RUN apt-get update 
-RUN apt-get -y install ldap-utils 
+RUN apt-get update
+RUN apt-get -y install ldap-utils
 RUN echo -e "slapd    slapd/internal/generated_adminpw    password admin\nslapd    slapd/password2    password admin\nslapd    slapd/internal/adminpw    password admin\nslapd    slapd/password1    password admin\n" | debconf-set-selections
-RUN apt-get -y install slapd 
+RUN apt-get -y install slapd
 EXPOSE 389/tcp
-RUN service slapd start
+RUN ulimit -n 1024 && service slapd start
 RUN echo olcSaslSecProps: noanonymous,minssf=0,passcred >> /etc/ldap/slapd.d/cn=config.ldif
-RUN  DEBIAN_FRONTEND=noninteractive apt-get -y install tshark 
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tshark
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 # entrypoint.sh
 #!/usr/bin/env bash
 
-service slapd start 
+ulimit -n 1024 && service slapd start 
 tshark -i any -f "port 389" -Y "ldap.protocolOp == 0 && ldap.simple" -e ldap.name -e ldap.simple -Tjson 2> /dev/null
 


### PR DESCRIPTION
fix #2

I found the answer here https://stackoverflow.com/questions/76332218/openldap-ch-calloc-core-dump-in-docker-containers

`ulimit -n 1024` was enough to fix

by the way I linted the spacing.